### PR TITLE
Fix bug of Sidebar.js not being viewable.

### DIFF
--- a/src/components/features/Sidebar/Sidebar.css
+++ b/src/components/features/Sidebar/Sidebar.css
@@ -10,7 +10,7 @@
 }
 
 .viewSidebar {
-    opacity: 100%;
+    opacity: 1.0;
 }
 
 .hideSidebar {


### PR DESCRIPTION
This bug is due to opacity value being set on a range of 0.0 to 1.0 which was not being done.