### PR TITLE
Implement scroll to top component

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start --no-cache",
     "build": "react-scripts build",
-    "test": "react-scripts test",
-    "test:coverage": "react-scripts test --coverage --watchAll=false",
+    "test": "react-scripts test --env=jsdom",
+    "test:coverage": "react-scripts test --coverage --watchAll=false --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "eslint .",
     "serve": "serve -s build"

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import Explore from "./components/features/Explore/Explore";
 import ConnectedDrink from "./components/features/Drink/Drink";
 import ConnectedSignup from './components/features/Signup/Signup';
 import ConnectedLogin from './components/features/Login/Login';
+import ScrollToTop from './components/common/ScrollToTop/ScrollToTop';
 
 
 
@@ -31,6 +32,7 @@ function App() {
           <ConnectedNavigation showMenuPaths={['/dashboard', '/user', '/drink', '/search', '/explore']}/>
           {/*Search bar for unauthed users who only want to search*/}
           {/*  Router which switches between components, Guard against auth routes*/}
+          <ScrollToTop />
           <Switch>
             <Route exact path="/" component={LandingPage} />
             <ProtectedRoute path="/dashboard" component={ConnectedDashboard} />

--- a/src/components/common/ScrollToTop/ScrollToTop.js
+++ b/src/components/common/ScrollToTop/ScrollToTop.js
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { withRouter } from 'react-router-dom';
+
+function ScrollToTop({ history }) {
+  useEffect(() => {
+    const unlisten = history.listen(() => {
+      window.scrollTo(0, 0);
+    });
+    return () => {
+      unlisten();
+    }
+  }, [history]);
+
+  return (null);
+}
+
+export default withRouter(ScrollToTop);

--- a/src/components/common/ScrollToTop/ScrollToTop.spec.js
+++ b/src/components/common/ScrollToTop/ScrollToTop.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from "react-router-dom";
+import { useHistory } from "react-router-dom";
+
+import ScrollToTop from './ScrollToTop';
+
+describe('ScrollToTop', () => {
+    it('should render.', () => {
+        const { container } = render(<MemoryRouter><ScrollToTop /></MemoryRouter>);
+        screen.debug('');
+        expect(container.querySelector('div')).not.toBeInTheDocument();
+    });
+
+    it('should scroll to top on route change.', () => {
+        const TestComponent = () => {
+            const history = useHistory();
+            return (
+                <button onClick={() => (history.push('/forward'))}>
+                </button>
+            )
+        };
+        const { container } = render(
+        <MemoryRouter>
+            <ScrollToTop />
+            <TestComponent />
+        </MemoryRouter>);
+        fireEvent.click(screen.getByRole('button'));
+        expect(container.querySelector('div')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Every route change should trigger a scroll to top now. Greying out currently used navigation is not a good idea. The UI looks worse with that. I would rather keep as is with 